### PR TITLE
dep: upgrade shiro to 1.9.1 to fix CVE-2022-32532.

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -14,7 +14,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <shiro.version>1.7.1</shiro.version>
+        <shiro.version>1.9.1</shiro.version>
         <java.version>1.8</java.version>
         <graalvm.version>20.1.0</graalvm.version>
         <knife4j.version>2.0.9</knife4j.version>


### PR DESCRIPTION
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-32532
https://lists.apache.org/thread/y8260dw8vbm99oq7zv6y3mzn5ovk90xh
https://it.ruc.edu.cn/wlaq/15d5b745423b4e73ad075a7f41e68aad.htm

Fixes # .

Changees proposed in this pull request:
-
-
-

@hummerisk-admins
